### PR TITLE
Ops 1419 percent busy metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ EverFi fork of the puma statsd plugin. Sends key [Puma][puma] metrics to [statsd
 
 Metrics:
 
-* puma.workers
-* puma.booted_workers
-* puma.running
-* puma.backlog
-* puma.pool_capacity
-* puma.max_threads
+* puma.workers - number of workers (for clustered mode)
+* puma.booted_workers - number of workers booted (for clustered mode)
+* puma.running - number of threads spawned currently
+* puma.backlog - number of requests waiting to be picked up by a thread
+* puma.pool_capacity - number of available threads to process requests
+* puma.max_threads - maximum number of threads that can be spawned
+* puma.percent_busy - percentage of max_threads that are currently processing requests
+
+When running puma in clustered mode, stats will be totals across all of the workers running
 
 In our case, these will be sent to datadog and tagged with:
 

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -106,6 +106,10 @@ class PumaStats
       @stats.fetch("max_threads", 0)
     end
   end
+
+  def percent_busy
+    ((1.0 - pool_capacity.to_f/max_threads.to_f)*100).round
+  end
 end
 
 Puma::Plugin.create do

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -164,6 +164,7 @@ Puma::Plugin.create do
         @statsd.send(metric_name: "puma.backlog", value: stats.backlog, type: :gauge, tags: tags)
         @statsd.send(metric_name: "puma.pool_capacity", value: stats.pool_capacity, type: :gauge, tags: tags)
         @statsd.send(metric_name: "puma.max_threads", value: stats.max_threads, type: :gauge, tags: tags)
+        @statsd.send(metric_name: "puma.percent_busy", value: stats.percent_busy, type: :gauge, tags: tags)
       rescue StandardError => e
         @launcher.events.error "! statsd: notify stats failed:\n  #{e.to_s}\n  #{e.backtrace.join("\n    ")}"
       ensure

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -108,6 +108,7 @@ class PumaStats
   end
 
   def percent_busy
+    return 0 if max_threads == 0
     ((1.0 - pool_capacity.to_f/max_threads.to_f)*100).round
   end
 end

--- a/test/puma_stats_test.rb
+++ b/test/puma_stats_test.rb
@@ -62,4 +62,9 @@ class PumaStatsTest < MiniTest::Test
     assert_equal 3, worker_stats.max_threads
   end
 
+  def test_percent_busy
+    assert_equal 33, cluster_stats.percent_busy
+    assert_equal 33, worker_stats.percent_busy
+  end
+
 end

--- a/test/puma_stats_test.rb
+++ b/test/puma_stats_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+class PumaStatsTest < MiniTest::Test
+  extend Minitest::Spec::DSL
+
+  let(:cluster_statistics) do
+    {
+        "workers" => 2,
+        "booted_workers" => 2,
+        "worker_status" => [worker_statistics,worker_statistics].map {|w| {"last_status" => w}}
+    }
+  end
+
+  let(:worker_statistics) do
+    {
+        "running" => 1,
+        "backlog" => 5,
+        "pool_capacity" => 2,
+        "max_threads" => 3
+    }
+  end
+
+  let(:cluster_stats) { PumaStats.new(cluster_statistics) }
+  let(:worker_stats) { PumaStats.new(worker_statistics) }
+
+  def setup
+    # Do nothing
+  end
+
+  def test_clustered?
+    assert cluster_stats.clustered?
+    refute worker_stats.clustered?
+  end
+
+  def test_workers
+    assert_equal 2,cluster_stats.workers
+    assert_equal 1,worker_stats.workers
+  end
+
+  def test_booted_workers
+    assert_equal 2,cluster_stats.booted_workers
+    assert_equal 1,worker_stats.booted_workers
+  end
+
+  def test_running
+    assert_equal 2, cluster_stats.running
+    assert_equal 1, worker_stats.running
+  end
+
+  def test_backlog
+    assert_equal 10, cluster_stats.backlog
+    assert_equal 5, worker_stats.backlog
+  end
+
+  def test_pool_capacity
+    assert_equal 4, cluster_stats.pool_capacity
+    assert_equal 2, worker_stats.pool_capacity
+  end
+
+  def test_max_threads
+    assert_equal 6, cluster_stats.max_threads
+    assert_equal 3, worker_stats.max_threads
+  end
+
+end

--- a/test/puma_stats_test.rb
+++ b/test/puma_stats_test.rb
@@ -67,4 +67,10 @@ class PumaStatsTest < MiniTest::Test
     assert_equal 33, worker_stats.percent_busy
   end
 
+  def test_percent_busy_zero_max_threads
+    ws = worker_statistics
+    ws["max_threads"] = 0
+    assert_equal 0, PumaStats.new(ws).percent_busy
+  end
+
 end


### PR DESCRIPTION
OPS-1419

Adds calculated metric for percent_busy.

Adds tests for the PumaStats class