### PR TITLE
OPS-1443 - Log error instead of exiting if failed to connect to statsd

### DIFF
--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -166,7 +166,7 @@ Puma::Plugin.create do
         @statsd.send(metric_name: "puma.max_threads", value: stats.max_threads, type: :gauge, tags: tags)
         @statsd.send(metric_name: "puma.percent_busy", value: stats.percent_busy, type: :gauge, tags: tags)
       rescue StandardError => e
-        @launcher.events.error "! statsd: notify stats failed:\n  #{e.to_s}\n  #{e.backtrace.join("\n    ")}"
+        @launcher.events.log "! statsd: notify stats failed:\n  #{e.to_s}\n  #{e.backtrace.join("\n    ")}"
       ensure
         sleep 2
       end


### PR DESCRIPTION
Calling `events.error` makes puma exit - https://github.com/puma/puma/blob/master/lib/puma/events.rb#L82.

I also changed this to rescue all just in case...