### PR TITLE
Ops 1805 histogram metrics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    puma-plugin-statsd (0.1.5)
+    puma-plugin-statsd (0.1.6)
       json
       puma (>= 3.12, < 5)
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ end
 ```
 
 
-## Testing the gem
+## Development
 
 Start a pretend statsd server that listens for UDP packets on port 8125:j
 
@@ -80,6 +80,12 @@ Throw some traffic at it, either with curl or a tool like ab:
     ab -n 10000 -c 20 http://127.0.0.1:9292/
 
 Watch the output of the UDP server process - you should see statsd data printed to stdout.
+
+### Tests
+
+This gem uses MiniTest for unit testing
+
+Run tests with `rake test`
 
 ## Acknowledgements
 

--- a/devtools/statsd-to-stdout.rb
+++ b/devtools/statsd-to-stdout.rb
@@ -7,5 +7,6 @@ server.bind(host, port)
 while true
   text, sender = server.recvfrom(64)
   remote_host = sender[3]
-  STDOUT.puts "#{remote_host}:" + text
+  time = Time.now.strftime('%H:%M:%S.%L')
+  STDOUT.puts "#{remote_host}:#{text} - #{time}"
 end

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -24,7 +24,7 @@ module PumaStatsd
 end
 
 class StatsdConnector
-  STATSD_TYPES = { count: 'c', gauge: 'g' }
+  STATSD_TYPES = { count: 'c', gauge: 'g', histogram: 'h' }
 
   attr_reader :host, :port
 

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -161,14 +161,14 @@ Puma::Plugin.create do
         @statsd.send(metric_name: "puma.workers", value: stats.workers, type: :gauge, tags: tags)
         @statsd.send(metric_name: "puma.booted_workers", value: stats.booted_workers, type: :gauge, tags: tags)
         @statsd.send(metric_name: "puma.running", value: stats.running, type: :gauge, tags: tags)
-        @statsd.send(metric_name: "puma.backlog", value: stats.backlog, type: :gauge, tags: tags)
-        @statsd.send(metric_name: "puma.pool_capacity", value: stats.pool_capacity, type: :gauge, tags: tags)
+        @statsd.send(metric_name: "puma.backlog", value: stats.backlog, type: :histogram, tags: tags)
+        @statsd.send(metric_name: "puma.pool_capacity", value: stats.pool_capacity, type: :histogram, tags: tags)
         @statsd.send(metric_name: "puma.max_threads", value: stats.max_threads, type: :gauge, tags: tags)
-        @statsd.send(metric_name: "puma.percent_busy", value: stats.percent_busy, type: :gauge, tags: tags)
+        @statsd.send(metric_name: "puma.percent_busy", value: stats.percent_busy, type: :histogram, tags: tags)
       rescue StandardError => e
         @launcher.events.log "! statsd: notify stats failed:\n  #{e.to_s}\n  #{e.backtrace.join("\n    ")}"
       ensure
-        sleep 2
+        sleep 0.5
       end
     end
   end

--- a/puma-plugin-statsd.gemspec
+++ b/puma-plugin-statsd.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name     = "puma-plugin-statsd"
-  spec.version  = "0.1.5"
+  spec.version  = "0.1.6"
   spec.author   = "James Healy"
   spec.email    = "james@yob.id.au"
 

--- a/test/statsd_connector_test.rb
+++ b/test/statsd_connector_test.rb
@@ -36,6 +36,54 @@ class StatsdConnectorTest < Minitest::Test
     assert mock_socket.verify
   end
 
+  def test_sends_count_metric
+    ENV["STATSD_HOST"] = 'test.com'
+    ENV["STATSD_PORT"] = '1234'
+    connector = StatsdConnector.new
+
+    mock_socket = Minitest::Mock.new
+    mock_socket.expect :send, true, ["test:1|c", Integer,String, String]
+    def mock_socket.close; nil; end
+
+    connector.stub :udp_socket, mock_socket do
+      connector.send(metric_name: 'test',value: 1,type: :count)
+    end
+
+    assert mock_socket.verify
+  end
+
+  def test_sends_gauge_metric
+    ENV["STATSD_HOST"] = 'test.com'
+    ENV["STATSD_PORT"] = '1234'
+    connector = StatsdConnector.new
+
+    mock_socket = Minitest::Mock.new
+    mock_socket.expect :send, true, ["test:1|g", Integer,String, String]
+    def mock_socket.close; nil; end
+
+    connector.stub :udp_socket, mock_socket do
+      connector.send(metric_name: 'test',value: 1,type: :gauge)
+    end
+
+    assert mock_socket.verify
+  end
+
+  def test_sends_histogram_metric
+    ENV["STATSD_HOST"] = 'test.com'
+    ENV["STATSD_PORT"] = '1234'
+    connector = StatsdConnector.new
+
+    mock_socket = Minitest::Mock.new
+    mock_socket.expect :send, true, ["test:1|h", Integer,String, String]
+    def mock_socket.close; nil; end
+
+    connector.stub :udp_socket, mock_socket do
+      connector.send(metric_name: 'test',value: 1,type: :histogram)
+    end
+
+    assert mock_socket.verify
+  end
+
   def teardown
     %w[STATSD_HOST STATSD_PORT].each {|var| ENV.delete var }
     PumaStatsd.reset_config


### PR DESCRIPTION
See JIRA ticket for background.  This modifies the plugin to send `puma.backlog`, `puma.pool_capacity`, and `puma.percent_busy` as histogram metrics instead of gauges.

This also changes the interval at which stats are sent from 2 seconds to .5 seconds.

NOTE:  This makes the plugin dependent on DataDog statsd because the histogram type is DataDog specific.  This will not work with a standard statsd implementation.

I added tests for the StatsdConnector but not for the plugin itself.  Setting up tests that mocked a puma instance with the plugin installed would be very complex given the way that plugins are registered into Puma.